### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/com.soulfiremc.soulfire.yml
+++ b/com.soulfiremc.soulfire.yml
@@ -54,7 +54,7 @@ modules:
     build-commands:
       - bsdtar -Oxf soulfire.deb "$(bsdtar -tf soulfire.deb | grep '^data.tar')" | bsdtar -xf -
       - cp -a opt/SoulFire /app/SoulFire
-      - patch-desktop-filename /app/SoulFire/resources/app.asar
+      - patch-electron-desktop-filename /app/SoulFire/resources/app.asar
       - install -Dm755 soulfire /app/bin/soulfire
       - desktop-file-edit --set-key=Exec --set-value='soulfire %U' --set-icon=com.soulfiremc.soulfire usr/share/applications/soulfire.desktop
       - install -Dm644 usr/share/applications/soulfire.desktop /app/share/applications/com.soulfiremc.soulfire.desktop


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.